### PR TITLE
fix: allow to run without failures during checkmode

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -61,6 +61,7 @@
     dest: "{{ openvpn_exporter_install_dir }}/{{ openvpn_exporter_version }}/openvpn_exporter"
     force: True
     checksum: "sha256:{{ __openvpn_exporter_checksum }}"
+  ignore_errors: "{{ ansible_check_mode }}"
   when: not openvpn_exporter_binary.stat.exists
   tags:
     - openvpn_exporter_install
@@ -73,6 +74,7 @@
     owner: "{{ openvpn_exporter_system_user }}"
     group: "{{ openvpn_exporter_system_group }}"
     mode: 0755
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Ensure latest binary is simlinked
   notify:


### PR DESCRIPTION
# Motivation

In order to check what the role would do, we want to run it with `--check-mode` during the first run. This currently fails in the download / permission phase 

# Description

adds a `ignore_errors` for relevant tasks when it is in check_mode